### PR TITLE
Lint エラーの解消 🍩

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,11 @@ module.exports = {
   ],
   // add your custom rules here
   rules: {
+    // devlopmentのときだけconsole.logを許可する
+    'no-console': process.env.NODE_ENV === 'production' ? 2 : 0,
+    // 末尾のセミコロンを許容する。
+    'comma-dangle': ['error', 'only-multiline'],
+    // 空白行に対してwarnのみ出るようにする。
+    'no-multiple-empty-lines': ['warn', {max: 1}]
   }
 }

--- a/components/Umbrella.vue
+++ b/components/Umbrella.vue
@@ -8,16 +8,22 @@
 <script>
 export default {
   props: {
-    primaryColor: String,
-    secondaryColor: String
+    primaryColor: {
+      type: String,
+      default: '#87ceeb'
+    },
+    secondaryColor: {
+      type: String,
+      default: '#ffa500'
+    }
   },
-  data: function () {
+  data() {
     return {
-      color: this.primaryColor || '#87ceeb'
+      color: this.primaryColor
     }
   },
   methods: {
-    changeColor: function () {
+    changeColor() {
       if (this.color === this.primaryColor) {
         this.color = this.secondaryColor
       } else {


### PR DESCRIPTION
## コンポーネントの関数定義を省略記法に変更
```javascript
data: function () {
    return {
      color: this.primaryColor
    }
  },
```
これを
```javascript
data() {
    return {
      color: this.primaryColor
    }
  },
```
こう変えたよー 🍟

## コンポーネントの props に default 値を設定
```javascript
props: {
    primaryColor: {
      type: String,
      default: '#87ceeb' // <= ここでデフォルト設定すれば、親から未設定でも大丈夫！
    },
    secondaryColor: {
      type: String,
      default: '#ffa500' // <= 同上
    }
  },
```
（この間の勉強会で説明してなくてゴメンな…… 🍙 ）

## Enhancement: lint のルールを追加
lint のエラーが厳し目なので、少し甘くする設定を入れてみました。
いらなかったら消して OK なのでー 🍕